### PR TITLE
Bump `golang.org/x/crypto` from `0.24.0` to `0.31.0` in `/bootstrap` to Fix Potential Authorization Bypass

### DIFF
--- a/bootstrap/go.mod
+++ b/bootstrap/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/mattn/go-sqlite3 v1.14.22
-	golang.org/x/crypto v0.24.0
+	golang.org/x/crypto v0.31.0
 	gorm.io/driver/sqlite v1.5.6
 	gorm.io/gorm v1.25.10
 )

--- a/bootstrap/go.sum
+++ b/bootstrap/go.sum
@@ -28,8 +28,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/crypto v0.24.0 h1:mnl8DM0o513X8fdIkmyFE/5hTYxbwYOjDS/+rK6qpRI=
-golang.org/x/crypto v0.24.0/go.mod h1:Z1PMYSOR5nyMcyAVAIQSKCDwalqy85Aqn1x3Ws4L5DM=
+golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
+golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/driver/sqlite v1.5.6 h1:fO/X46qn5NUEEOZtnjJRWRzZMe8nqJiQ9E+0hi+hKQE=


### PR DESCRIPTION
This PR updates `golang.org/x/crypto` from version `0.24.0` to `0.31.0` in the `/bootstrap` directory to address a potential security issue related to the misuse of `ServerConfig.PublicKeyCallback`, which could lead to an authorization bypass.  

Key Changes:  
- Upgraded `golang.org/x/crypto` to `0.31.0` to incorporate security fixes and improvements.  
- Mitigates the risk of improperly handling `PublicKeyCallback`, which could allow unauthorized access in certain configurations.  
- Ensures compatibility with the latest security patches and upstream improvements.  

References:  
- [golang/go issue discussing PublicKeyCallback misuse](https://github.com/golang/go/issues) *(add the relevant issue link if available)*  
- [Changelog for golang.org/x/crypto](https://github.com/golang/crypto/blob/master/README.md) *(ensure it includes relevant updates)*  

This update is essential to maintaining security and reliability in authentication mechanisms. Please review and merge at your earliest convenience. 🚀